### PR TITLE
allow to have 'glued' comments to selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,14 @@ module.exports = {
 				]
 			}
 		],
-		'rule-non-nested-empty-line-before': 'always',
+		'rule-non-nested-empty-line-before': [
+			'always',
+			{
+				'ignore': [
+					'after-comment'
+				]
+			}
+		],
 		'selector-class-pattern': '^[a-zA-Z0-9-]+$',
 		'selector-combinator-space-after': 'always',
 		'selector-combinator-space-before': 'always',


### PR DESCRIPTION
the linter warns us if we have code like this:

``` scss
// this stuff is super cool
.Stuff {
    font-family: Lato;
}
```

Contrary to what you might believe, the linter's problem is not that we use _Lato_.
The problem is that the comment is too close to the selector. There should be one empty line between a comment and a non-nested selector according to the rule `rule-non-nested-empty-line-before`.

I think this is too restrictive and we should allow comments like that.
