### PR TITLE
allow consecutive duplicate properties for fallback values

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ module.exports = {
 		'comment-whitespace-inside': 'always',
 		'declaration-bang-space-after': 'never',
 		'declaration-bang-space-before': 'always',
-		'declaration-block-no-duplicate-properties': true,
+		'declaration-block-no-duplicate-properties': [
+			true,
+			{
+				'ignore': ['consecutive-duplicates']
+			}
+		],
 		'declaration-block-no-shorthand-property-overrides': true,
 		'declaration-block-semicolon-newline-after': 'always',
 		'declaration-block-semicolon-newline-before': 'never-multi-line',


### PR DESCRIPTION
For now the linter doesn't allow us to duplicate properties. We should be able
to in order to write fallbacks values.
For examples, if I want to use viewport related units (_vh_, _vw_), or use _rgba_ colors,
and I unfortunately need to support IE8 just because, I need to write alternative values
next to the cool ones.
