### PR TITLE
allow universal selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ module.exports = {
 		'selector-list-comma-space-after': 'always-single-line',
 		'selector-list-comma-space-before': 'never',
 		'selector-no-id': true,
-		'selector-no-universal': true,
 		'selector-pseudo-element-colon-notation': 'single',
 		'string-no-newline': true,
 		'string-quotes': 'single',


### PR DESCRIPTION
We know this selector should be used ligthly, but I think it is great on some usecases.
When dealing with strict DOM structure like forms or global layout, it can be quite
useful to target elements with selectors like `.ParentElement > *`.

I think exclusively allowing `> *` would be great but there is no linter options to allow only that.
What should we do then? The straightforward way in this commit is to remove the rule totally...
